### PR TITLE
Bug Fix for v0.8 feature configureable hystrix bundle

### DIFF
--- a/src/main/java/org/zapodot/hystrix/bundle/HystrixBundle.java
+++ b/src/main/java/org/zapodot/hystrix/bundle/HystrixBundle.java
@@ -22,12 +22,19 @@ public class HystrixBundle<T extends Configuration> implements ConfiguredBundle<
      */
     @SuppressWarnings("squid:S1075")
     public static final String DEFAULT_STREAM_PATH = "/hystrix.stream";
+    public static final boolean DEFAULT_PUBLISH_HYSTRIX_METRICS = true;
     public static final String SERVLET_NAME = "hystrixMetricsStream";
     private static final Logger logger = LoggerFactory.getLogger(HystrixBundle.class);
+
     private final String adminStreamPath;
     private final String applicationStreamUri;
     private final boolean publishHystrixMetrics;
 
+    public HystrixBundle() {
+        this.adminStreamPath = DEFAULT_STREAM_PATH;
+        this.applicationStreamUri = null;
+        this.publishHystrixMetrics = DEFAULT_PUBLISH_HYSTRIX_METRICS;
+    }
 
     /**
      * The one and only constructor. Use either @{link #withDefaultSettings} or @{link builder}
@@ -37,7 +44,7 @@ public class HystrixBundle<T extends Configuration> implements ConfiguredBundle<
      * @param applicationStreamUri
      * @param publishHystrixMetrics
      */
-    HystrixBundle(final String adminStreamPath,
+    public HystrixBundle(final String adminStreamPath,
                   final String applicationStreamUri,
                   final boolean publishHystrixMetrics) {
         this.adminStreamPath = adminStreamPath;
@@ -133,7 +140,7 @@ public class HystrixBundle<T extends Configuration> implements ConfiguredBundle<
     public static class Builder {
         private String adminPath = DEFAULT_STREAM_PATH;
         private String applicationPath;
-        private boolean publishHystrixMetrics = true;
+        private boolean publishHystrixMetrics = DEFAULT_PUBLISH_HYSTRIX_METRICS;
 
         /**
          * Configure the path that the HystrixMetricsStreamServlet will be mapped to in the admin context

--- a/src/main/java/org/zapodot/hystrix/bundle/HystrixBundle.java
+++ b/src/main/java/org/zapodot/hystrix/bundle/HystrixBundle.java
@@ -31,9 +31,7 @@ public class HystrixBundle<T extends Configuration> implements ConfiguredBundle<
     private final boolean publishHystrixMetrics;
 
     public HystrixBundle() {
-        this.adminStreamPath = DEFAULT_STREAM_PATH;
-        this.applicationStreamUri = null;
-        this.publishHystrixMetrics = DEFAULT_PUBLISH_HYSTRIX_METRICS;
+        this(DEFAULT_STREAM_PATH, null, DEFAULT_PUBLISH_HYSTRIX_METRICS);
     }
 
     /**

--- a/src/test/java/com/test/application/ExternalAppTest.java
+++ b/src/test/java/com/test/application/ExternalAppTest.java
@@ -1,0 +1,18 @@
+package com.test.application;
+
+import io.dropwizard.Configuration;
+import org.junit.Test;
+import org.zapodot.hystrix.bundle.HystrixBundle;
+
+
+public class ExternalAppTest {
+
+    @Test
+    public void shouldBeAbleToCreateBundleWithoutUsingBuilder(){
+        new HystrixBundle<Configuration>("random","random", false) {
+            protected boolean canPublishHystrixMetrics(Configuration configuration) {
+                return true;
+            }
+        };
+    }
+}

--- a/src/test/java/org/zapodot/hystrix/bundle/HystrixBundleTest.java
+++ b/src/test/java/org/zapodot/hystrix/bundle/HystrixBundleTest.java
@@ -43,8 +43,8 @@ public class HystrixBundleTest {
     }
 
     @Test
-    public void testWithDefaults() throws Exception {
-        final HystrixBundle hystrixBundle = HystrixBundle.withDefaultSettings();
+    public void testWithDefaultsUsingConstructor() throws Exception {
+        final HystrixBundle hystrixBundle = new HystrixBundle();
         hystrixBundle.initialize(bootstrap);
         hystrixBundle.run(configuration, environment);
         assertNotNull(environment.getAdminContext()
@@ -53,6 +53,21 @@ public class HystrixBundleTest {
         assertNull(environment.getApplicationContext()
                               .getServletContext()
                               .getServletRegistration(HystrixBundle.SERVLET_NAME));
+        assertTrue(HystrixPlugins.getInstance().getMetricsPublisher() instanceof HystrixCodaHaleMetricsPublisher);
+        verifyZeroInteractions(bootstrap);
+    }
+
+    @Test
+    public void testWithDefaultsUsingBuilder() throws Exception {
+        final HystrixBundle hystrixBundle = HystrixBundle.withDefaultSettings();
+        hystrixBundle.initialize(bootstrap);
+        hystrixBundle.run(configuration, environment);
+        assertNotNull(environment.getAdminContext()
+                .getServletContext()
+                .getServletRegistration(HystrixBundle.SERVLET_NAME));
+        assertNull(environment.getApplicationContext()
+                .getServletContext()
+                .getServletRegistration(HystrixBundle.SERVLET_NAME));
         assertTrue(HystrixPlugins.getInstance().getMetricsPublisher() instanceof HystrixCodaHaleMetricsPublisher);
         verifyZeroInteractions(bootstrap);
     }


### PR DESCRIPTION
Bug Fix: To make use of feature released in v0.8 Configureable hystrix
bundle, the constructor of the bundle should be public to extend the
class. Looks like the bundler is always configured using the Builder
and this issue has never occurred/been reported.

Also this has been missed out in unit testing PR#3. As the test class is
under the same package this was unnoticed during that time.
