### PR TITLE
MetricsPublishPredicate predicate input should be of type Configuration.

### DIFF
--- a/src/main/java/org/zapodot/hystrix/bundle/HystrixBundle.java
+++ b/src/main/java/org/zapodot/hystrix/bundle/HystrixBundle.java
@@ -114,13 +114,13 @@ public class HystrixBundle<T extends Configuration> implements ConfiguredBundle<
      * Predicate to be used for deciding whether Hystrix Metrics should be published through DropWizard or not
      */
     @FunctionalInterface
-    public interface MetricsPublishPredicate<T> {
+    public interface MetricsPublishPredicate<V extends Configuration> {
 
         /**
          * Is publishing enabled?
          * @return true to enable, false to disable
          */
-        boolean enabled(T configuration);
+        boolean enabled(V configuration);
     }
 
     /**


### PR DESCRIPTION
Without this change, you need to typecast(manually) configuration object
which <T> is of type Object and this is somewhat scary.

With the new change, the predicate type is of `Configuration` and feels
bit safer to typecast(manually) from Configuration to MyAppConfiguration
than from Object.

PS: This wouldn't be the case if the inner interface had access to outer class <T>.